### PR TITLE
Init project

### DIFF
--- a/c2-01-variables.tf
+++ b/c2-01-variables.tf
@@ -96,10 +96,14 @@ variable "custom_node_pool" {
     eviction_policy       = optional(string)                  # for Spot: "Delete" or "Deallocate"
     spot_max_price        = optional(number)                  # for Spot: -1 or a price in USD/hour
     zones                 = optional(list(string))
-    upgrade_settings      = object({
+    upgrade_settings     = optional(object({
       drain_timeout_in_minutes      = optional(number, 30)
       node_soak_duration_in_minutes = optional(number, 0)
       max_surge                     = optional(string, "33%")
+    }), {
+      drain_timeout_in_minutes      = 30
+      node_soak_duration_in_minutes = 0
+      max_surge                     = "33%"
     })
   }))
   default = []

--- a/c3-aks.tf
+++ b/c3-aks.tf
@@ -104,9 +104,5 @@ data "azurerm_subscription" "primary" {}
 resource "azurerm_role_assignment" "acr_pull_subscription_wide" {
   scope                = data.azurerm_subscription.primary.id
   role_definition_name = "AcrPull"
-<<<<<<< HEAD
-  principal_id         = azurerm_kubernetes_cluster.aks_cluster.kubelet_identity[0].object_id
-=======
   principal_id         = azurerm_kubernetes_cluster.aks_cluster.identity[0].principal_id                 
->>>>>>> cf8d0c8341658299a943f7075714fc0e02df1867
 }

--- a/c3-aks.tf
+++ b/c3-aks.tf
@@ -104,5 +104,5 @@ data "azurerm_subscription" "primary" {}
 resource "azurerm_role_assignment" "acr_pull_subscription_wide" {
   scope                = data.azurerm_subscription.primary.id
   role_definition_name = "AcrPull"
-  principal_id         = azurerm_kubernetes_cluster.aks.kubelet_identity[0].object_id
+  principal_id         = azurerm_kubernetes_cluster.aks_cluster.kubelet_identity[0].object_id
 }

--- a/c4-aks-custom-node-pool.tf
+++ b/c4-aks-custom-node-pool.tf
@@ -40,8 +40,9 @@ resource "azurerm_kubernetes_cluster_node_pool" "this" {
   dynamic "upgrade_settings" {
     for_each = each.value.priority == "Spot" ? [] : [1]
     content {
-      max_surge                  = "33%" // A sensible default for non-Spot pools
-      drain_timeout_in_minutes   = 30
+      max_surge                     = each.value.upgrade_settings.max_surge
+      drain_timeout_in_minutes      = each.value.upgrade_settings.drain_timeout_in_minutes
+      node_soak_duration_in_minutes = each.value.upgrade_settings.node_soak_duration_in_minutes
     }
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Per-node-pool upgrade settings are now configurable with sensible defaults when omitted, including support for node soak duration; applied to non-Spot pools.

* Documentation
  * Added guidance for ACR integration: assign AcrPull to the kubelet identity at subscription scope.
  * Expanded prerequisites to include permission to create subscription-level role assignments.
  * Clarified that default and custom node pools use upgrade_settings by default unless overridden.
  * Noted that Spot pools skip upgrade_settings to avoid conflicts.
  * Added examples reflecting Spot pool considerations and updated formatting for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->